### PR TITLE
Solution to Gophercises Exercise 14: Recover Middleware

### DIFF
--- a/recover.go
+++ b/recover.go
@@ -34,6 +34,8 @@ func (rmux *RecoverMux) HandleFunc(pattern string, handler func(http.ResponseWri
 				rmux.recoverHandler(w, r)
 			}
 		}()
+		// Use a responseWriter to buffer the user's handler's response
+		// so it can be thrown away in the event of a panic.
 		rw := newResponseWriter(w)
 		handler(rw, r)
 		err := rw.complete()

--- a/recover.go
+++ b/recover.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type recoverMux struct {
+	mux *http.ServeMux
+}
+
+func newRecoverMux() *recoverMux {
+	return &recoverMux{
+		mux: http.NewServeMux(),
+	}
+}
+
+func (rmux *recoverMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if x := recover(); x != nil {
+				recoverHandler(w, r)
+			}
+		}()
+		handler(w, r)
+	}
+	rmux.mux.HandleFunc(pattern, f)
+}
+
+func (rmux *recoverMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rmux.mux.ServeHTTP(w, r)
+}
+
+func recoverHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Something went wrong.")
+}

--- a/recover.go
+++ b/recover.go
@@ -1,20 +1,29 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net/http"
 )
 
+// A recoverMux recovers from panics during an http.Handler, sending an error
+// response to a client in the event a panic occurs.
 type recoverMux struct {
 	mux *http.ServeMux
 }
 
+// NewRecoverMux returns a new recoverMux, creating and wrapping a new
+// http.ServeMux.
 func newRecoverMux() *recoverMux {
 	return &recoverMux{
 		mux: http.NewServeMux(),
 	}
 }
 
+// HandleFunc wraps the caller's handler with a recovery handler which recovers
+// from panics in the caller's handler. Response data is only written if the
+// caller's handler completes without panicking.
 func (rmux *recoverMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -22,15 +31,69 @@ func (rmux *recoverMux) HandleFunc(pattern string, handler func(http.ResponseWri
 				recoverHandler(w, r)
 			}
 		}()
-		handler(w, r)
+		rw := newResponseWriter(w)
+		handler(rw, r)
+		err := rw.complete()
+		if err != nil {
+			log.Printf("error completing handler (URL %s): %s", r.URL, err.Error())
+		}
 	}
 	rmux.mux.HandleFunc(pattern, f)
 }
 
+// ServeHTTP uses the wrapped http.ServeMux to serve recoverable handlers.
 func (rmux *recoverMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rmux.mux.ServeHTTP(w, r)
 }
 
+// RecoverHandler is the handler invoked when the client's handler panics.
 func recoverHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Something went wrong.")
+}
+
+// A responseWriter wraps http.ResponseWriter for a recoverMux.
+type responseWriter struct {
+	buf *bytes.Buffer
+	sc  int
+	w   http.ResponseWriter
+}
+
+// NewResponseWriter returns a new responseWriter for an http.ResponseWriter
+// for passing to a real handler by the recoverMux's handler.
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{
+		buf: &bytes.Buffer{},
+		sc:  -1, // Flag value to indicate it has not been written
+		w:   w,
+	}
+}
+
+// Header simply returns the real http.ResponseWriter's Header.
+func (w *responseWriter) Header() http.Header {
+	return w.w.Header()
+}
+
+// Write buffers response writes so the recoverMux can throw them away in case
+// the real handler panics.
+func (w *responseWriter) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+// WriteHeader saves the status code from the real handler so it can be thrown
+// away if the real handler panics. It panics if the code is not valid.
+func (w *responseWriter) WriteHeader(statusCode int) {
+	if statusCode < 100 || statusCode > 999 {
+		panic(fmt.Sprintf("invalid WriteHeader code %v", statusCode))
+	}
+	w.sc = statusCode
+}
+
+// Complete sends the full response to the client in cases where the real
+// handler completes without panicking.
+func (w *responseWriter) complete() error {
+	if w.sc > 0 {
+		w.w.WriteHeader(w.sc)
+	}
+	_, err := w.w.Write(w.buf.Bytes())
+	return err
 }

--- a/recover_test.go
+++ b/recover_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type testHandler interface {
+	Handle(http.ResponseWriter, *http.Request)
+	response() []byte
+	desc() string
+}
+
+func TestRecoverMux(t *testing.T) {
+	// Some server URL stuff
+	addr := ":5050"
+	path := "/test"
+	url := "http://localhost" + addr + path
+
+	// Test table
+	ths := []testHandler{
+		newTestHandlerOK("handler OK"),
+	}
+
+	// Run each test in the table
+	for _, th := range ths {
+		// Create recoverMux under test
+		mux := newRecoverMux()
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			th.Handle(w, r)
+		})
+		s := &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		}
+
+		// Start server
+		go s.ListenAndServe()
+
+		// Get response from server
+		resp, err := http.Get(url)
+
+		// Ensure normal response
+		if err != nil {
+			t.Errorf("test error: %s HTTP GET error %s\n", th.desc(), err.Error())
+		} else {
+			// Read response body
+			var bresp []byte
+			bresp, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("test error: %s read response error %s", th.desc(), err.Error())
+			}
+
+			// Check response body equals expected value
+			if !bytes.Equal(th.response(), bresp) {
+				t.Errorf("test error: %s response not equal to expected response", th.desc())
+			}
+
+			resp.Body.Close()
+		}
+
+		// Close server
+		err = s.Close()
+		if err != nil {
+			t.Errorf("test error: %s close error %s", th.desc(), err.Error())
+		}
+	}
+}
+
+type testHandlerOK struct {
+	resp string
+}
+
+func newTestHandlerOK(resp string) testHandler {
+	return &testHandlerOK{
+		resp: resp,
+	}
+}
+
+func (h *testHandlerOK) Handle(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, h.resp)
+}
+
+func (h *testHandlerOK) response() []byte {
+	return []byte(h.resp)
+}
+
+func (h *testHandlerOK) desc() string {
+	return h.resp
+}


### PR DESCRIPTION
My solution uses a recoverMux which emulates and wraps an http.ServeMux. Registered handlers are wrapped with another function which defers a recover handler, calls the user's handler, and writes the user's response if the handler completes without panicking. A responseWriter emulates and wraps the http.ResponseWriter to buffer the user's response and status code so they are only sent to the client if the user's handler completes without panicking. A DumpStack flag in the recoverMux additionally writes a stack dump to the client when the user's handler panics.